### PR TITLE
Align default containers with jax

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
     hooks:
     -   id: interrogate
         args: [-v, --fail-under=20]
-        exclude: ^(docs|setup\.py)
+        exclude: ^(tests|docs|setup\.py)
 - repo: https://github.com/codespell-project/codespell
   rev: v2.1.0
   hooks:

--- a/src/pybaum/registry.py
+++ b/src/pybaum/registry.py
@@ -1,7 +1,7 @@
 from pybaum.registry_entries import FUNC_DICT
 
 
-def get_registry(types=None, options=None, include_defaults=True):
+def get_registry(types=None, include_defaults=True):
     """Create a pytree registry.
 
     Args:
@@ -11,12 +11,12 @@ def get_registry(types=None, options=None, include_defaults=True):
             - "tuple"
             - "dict"
             - "list"
+            - "namedtuple"
+            - "None"
+            - "OrderedDict"
             - "numpy.ndarray"
             - "pandas.Series"
             - "pandas.DataFrame"
-        options (dict): Option dictionary where the keys are names of types and the
-            values are keyword arguments that influence how containers are flattened
-            and unflattened.
         include_defaults (bool): Whether the default pytree containers "tuple", "dict"
             "list", "None", "namedtuple" and "OrderedDict" should be included even if
             not specified in `types`.
@@ -31,11 +31,9 @@ def get_registry(types=None, options=None, include_defaults=True):
         default_types = {"list", "tuple", "dict", "None", "namedtuple", "OrderedDict"}
         types = list(set(types) | default_types)
 
-    options = {} if options is None else options
-
     registry = {}
     for typ in types:
-        new_entry = FUNC_DICT[typ](**options.get(typ, {}))
+        new_entry = FUNC_DICT[typ]()
         registry = {**registry, **new_entry}
 
     return registry

--- a/src/pybaum/registry.py
+++ b/src/pybaum/registry.py
@@ -11,9 +11,9 @@ def get_registry(types=None, include_defaults=True):
             - "tuple"
             - "dict"
             - "list"
-            - "namedtuple"
-            - "None"
-            - "OrderedDict"
+            - :class:`collections.namedtuple` or :class:`typing.NamedTuple`
+            - :obj:`None`
+            - :class:`collections.OrderedDict`
             - "numpy.ndarray"
             - "pandas.Series"
             - "pandas.DataFrame"

--- a/src/pybaum/registry.py
+++ b/src/pybaum/registry.py
@@ -28,7 +28,8 @@ def get_registry(types=None, options=None, include_defaults=True):
     types = [] if types is None else types
 
     if include_defaults:
-        types = list(set(types) | {"list", "tuple", "dict", "None", "namedtuple"})
+        default_types = {"list", "tuple", "dict", "None", "namedtuple", "OrderedDict"}
+        types = list(set(types) | default_types)
 
     options = {} if options is None else options
 

--- a/src/pybaum/registry.py
+++ b/src/pybaum/registry.py
@@ -18,7 +18,8 @@ def get_registry(types=None, options=None, include_defaults=True):
             values are keyword arguments that influence how containers are flattened
             and unflattened.
         include_defaults (bool): Whether the default pytree containers "tuple", "dict"
-            and "list" should be included even if not specified in `types`.
+            "list", "None", "namedtuple" and "OrderedDict" should be included even if
+            not specified in `types`.
 
     Returns:
         dict: A pytree registry.
@@ -27,7 +28,7 @@ def get_registry(types=None, options=None, include_defaults=True):
     types = [] if types is None else types
 
     if include_defaults:
-        types = list(set(types) | {"list", "tuple", "dict"})
+        types = list(set(types) | {"list", "tuple", "dict", "None"})
 
     options = {} if options is None else options
 

--- a/src/pybaum/registry.py
+++ b/src/pybaum/registry.py
@@ -28,7 +28,7 @@ def get_registry(types=None, options=None, include_defaults=True):
     types = [] if types is None else types
 
     if include_defaults:
-        types = list(set(types) | {"list", "tuple", "dict", "None"})
+        types = list(set(types) | {"list", "tuple", "dict", "None", "namedtuple"})
 
     options = {} if options is None else options
 

--- a/src/pybaum/registry_entries.py
+++ b/src/pybaum/registry_entries.py
@@ -11,6 +11,17 @@ if IS_PANDAS_INSTALLED:
     import pandas as pd
 
 
+def _none():
+    entry = {
+        type(None): {
+            "flatten": lambda tree: ([], None),  # noqa: U100
+            "unflatten": lambda aux_data, children: None,  # noqa: U100
+            "names": lambda tree: [],  # noqa: U100
+        }
+    }
+    return entry
+
+
 def _list():
     entry = {
         list: {
@@ -161,4 +172,5 @@ FUNC_DICT = {
     "numpy.ndarray": _numpy_array,
     "pandas.Series": _pandas_series,
     "pandas.DataFrame": _pandas_dataframe,
+    "None": _none,
 }

--- a/src/pybaum/registry_entries.py
+++ b/src/pybaum/registry_entries.py
@@ -1,4 +1,5 @@
 import itertools
+from collections import namedtuple
 from functools import partial
 
 from pybaum.config import IS_NUMPY_INSTALLED
@@ -53,6 +54,23 @@ def _tuple():
         },
     }
     return entry
+
+
+def _namedtuple():
+    entry = {
+        namedtuple: {
+            "flatten": lambda tree: (list(tree), tree),
+            "unflatten": _unflatten_namedtuple,
+            "names": lambda tree: list(tree._fields),
+        },
+    }
+    return entry
+
+
+def _unflatten_namedtuple(aux_data, leaves):
+    replacements = dict(zip(aux_data._fields, leaves))
+    out = aux_data._replace(**replacements)
+    return out
 
 
 def _numpy_array():
@@ -173,4 +191,5 @@ FUNC_DICT = {
     "pandas.Series": _pandas_series,
     "pandas.DataFrame": _pandas_dataframe,
     "None": _none,
+    "namedtuple": _namedtuple,
 }

--- a/src/pybaum/registry_entries.py
+++ b/src/pybaum/registry_entries.py
@@ -14,6 +14,7 @@ if IS_PANDAS_INSTALLED:
 
 
 def _none():
+    """Create registry entry for NoneType."""
     entry = {
         type(None): {
             "flatten": lambda tree: ([], None),  # noqa: U100
@@ -25,6 +26,7 @@ def _none():
 
 
 def _list():
+    """Create registry entry for list."""
     entry = {
         list: {
             "flatten": lambda tree: (tree, None),
@@ -36,6 +38,7 @@ def _list():
 
 
 def _dict():
+    """Create registry entry for dict."""
     entry = {
         dict: {
             "flatten": lambda tree: (list(tree.values()), list(tree)),
@@ -47,6 +50,7 @@ def _dict():
 
 
 def _tuple():
+    """Create registry entry for tuple."""
     entry = {
         tuple: {
             "flatten": lambda tree: (list(tree), None),
@@ -58,6 +62,7 @@ def _tuple():
 
 
 def _namedtuple():
+    """Create registry entry for namedtuple and NamedTuple."""
     entry = {
         namedtuple: {
             "flatten": lambda tree: (list(tree), tree),
@@ -75,6 +80,7 @@ def _unflatten_namedtuple(aux_data, leaves):
 
 
 def _ordereddict():
+    """Create registry entry for OrderedDict."""
     entry = {
         OrderedDict: {
             "flatten": lambda tree: (list(tree.values()), list(tree)),
@@ -88,11 +94,8 @@ def _ordereddict():
 
 
 def _numpy_array():
-    """Create a pytree declaration for numpy arrays.
+    """Create registry entry for numpy.ndarray."""
 
-    To-Do: Add optional axis argument.
-
-    """
     if IS_NUMPY_INSTALLED:
         entry = {
             np.ndarray: {
@@ -115,6 +118,7 @@ def _array_element_names(arr):
 
 
 def _pandas_series():
+    """Create registry entry for pandas.Series."""
     if IS_PANDAS_INSTALLED:
         entry = {
             pd.Series: {
@@ -132,6 +136,7 @@ def _pandas_series():
 
 
 def _pandas_dataframe(columns=None):
+    """Create registry entry for pandas.DataFrame."""
     if IS_PANDAS_INSTALLED:
         entry = {
             pd.DataFrame: {

--- a/src/pybaum/registry_entries.py
+++ b/src/pybaum/registry_entries.py
@@ -1,5 +1,6 @@
 import itertools
 from collections import namedtuple
+from collections import OrderedDict
 from functools import partial
 
 from pybaum.config import IS_NUMPY_INSTALLED
@@ -71,6 +72,19 @@ def _unflatten_namedtuple(aux_data, leaves):
     replacements = dict(zip(aux_data._fields, leaves))
     out = aux_data._replace(**replacements)
     return out
+
+
+def _ordereddict():
+    entry = {
+        OrderedDict: {
+            "flatten": lambda tree: (list(tree.values()), list(tree)),
+            "unflatten": lambda aux_data, children: OrderedDict(
+                zip(aux_data, children)
+            ),
+            "names": lambda tree: list(map(str, list(tree))),
+        },
+    }
+    return entry
 
 
 def _numpy_array():
@@ -192,4 +206,5 @@ FUNC_DICT = {
     "pandas.DataFrame": _pandas_dataframe,
     "None": _none,
     "namedtuple": _namedtuple,
+    "OrderedDict": _ordereddict,
 }

--- a/src/pybaum/tree_util.py
+++ b/src/pybaum/tree_util.py
@@ -10,6 +10,7 @@ import itertools
 
 from pybaum.equality import EQUALITY_CHECKERS
 from pybaum.registry import get_registry
+from pybaum.typecheck import get_type
 
 
 def tree_flatten(tree, is_leaf=None, registry=None):
@@ -80,14 +81,14 @@ def tree_just_flatten(tree, is_leaf=None, registry=None):
 
 def _tree_flatten(tree, is_leaf, registry):
     out = []
-    tree_type = type(tree)
+    tree_type = get_type(tree)
 
     if tree_type not in registry or is_leaf(tree):
         out.append(tree)
     else:
         subtrees, _ = registry[tree_type]["flatten"](tree)
         for subtree in subtrees:
-            if type(subtree) in registry:
+            if get_type(subtree) in registry:
                 out += _tree_flatten(subtree, is_leaf, registry)
             else:
                 out.append(subtree)
@@ -161,14 +162,14 @@ def tree_just_yield(tree, is_leaf=None, registry=None):
 
 def _tree_yield(tree, is_leaf, registry):
     out = []
-    tree_type = type(tree)
+    tree_type = get_type(tree)
 
     if tree_type not in registry or is_leaf(tree):
         yield tree
     else:
         subtrees, _ = registry[tree_type]["flatten"](tree)
         for subtree in subtrees:
-            if type(subtree) in registry:
+            if get_type(subtree) in registry:
                 yield from _tree_yield(subtree, is_leaf, registry)
             else:
                 yield subtree
@@ -211,7 +212,7 @@ def tree_unflatten(treedef, leaves, is_leaf=None, registry=None):
 
 def _tree_unflatten(treedef, leaves, is_leaf, registry):
     leaves = iter(leaves)
-    tree_type = type(treedef)
+    tree_type = get_type(treedef)
 
     if tree_type not in registry or is_leaf(treedef):
         return next(leaves)
@@ -219,7 +220,7 @@ def _tree_unflatten(treedef, leaves, is_leaf, registry):
         items, info = registry[tree_type]["flatten"](treedef)
         unflattened_items = []
         for item in items:
-            if type(item) in registry:
+            if get_type(item) in registry:
                 unflattened_items.append(
                     _tree_unflatten(item, leaves, is_leaf=is_leaf, registry=registry)
                 )
@@ -336,7 +337,7 @@ def leaf_names(tree, is_leaf=None, registry=None, separator="_"):
 
 def _leaf_names(tree, is_leaf, registry, separator, prefix=None):
     out = []
-    tree_type = type(tree)
+    tree_type = get_type(tree)
 
     if tree_type not in registry or is_leaf(tree):
         out.append(prefix)
@@ -344,7 +345,7 @@ def _leaf_names(tree, is_leaf, registry, separator, prefix=None):
         subtrees, info = registry[tree_type]["flatten"](tree)
         names = registry[tree_type]["names"](tree)
         for name, subtree in zip(names, subtrees):
-            if type(subtree) in registry:
+            if get_type(subtree) in registry:
                 out += _leaf_names(
                     subtree,
                     is_leaf=is_leaf,
@@ -424,7 +425,7 @@ def tree_equal(tree, other, is_leaf=None, registry=None, equality_checkers=None)
 
     if equal:
         for first, second in zip(first_flat, second_flat):
-            check_func = equality_checkers.get(type(first), lambda a, b: a == b)
+            check_func = equality_checkers.get(get_type(first), lambda a, b: a == b)
             equal = equal and check_func(first, second)
             if not equal:
                 break

--- a/src/pybaum/typecheck.py
+++ b/src/pybaum/typecheck.py
@@ -1,0 +1,31 @@
+from collections import namedtuple
+
+
+def get_type(obj):
+    """namdetuple aware type check.
+
+    As in JAX we treat collections.namedtuple and typing.NamedTuple both as
+    namedtuple but the exact type is preserved in the unflatten function.
+
+    namedtuples are discovered by being instances of tuple and having a
+    ``_fields`` attribute as suggested by Raymond Hettinger
+    `here <https://bugs.python.org/issue7796>`_.
+
+    Moreover we check for the presence of a ``_replace`` method because we need when
+    unflattening pytrees.
+
+    This can produce false positives but in most cases would still result in desired
+    behavior.
+
+    Args:
+        obj: The object to be checked
+
+    Returns:
+        bool
+
+    """
+    if isinstance(obj, tuple) and hasattr(obj, "_fields") and hasattr(obj, "_replace"):
+        out = namedtuple
+    else:
+        out = type(obj)
+    return out

--- a/tests/test_tree_util.py
+++ b/tests/test_tree_util.py
@@ -1,5 +1,6 @@
 import inspect
 from collections import namedtuple
+from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
@@ -234,4 +235,16 @@ def test_flatten_with_namedtuple():
 def test_names_with_namedtuple():
     bla = namedtuple("bla", ["a", "b"])(1, 2)
     names = leaf_names(bla)
+    assert names == ["a", "b"]
+
+
+def test_flatten_with_ordered_dict():
+    d = OrderedDict({"a": 1, "b": 2})
+    flat, _ = tree_flatten(d)
+    assert flat == [1, 2]
+
+
+def test_names_with_ordered_dict():
+    d = OrderedDict({"a": 1, "b": 2})
+    names = leaf_names(d)
     assert names == ["a", "b"]

--- a/tests/test_tree_util.py
+++ b/tests/test_tree_util.py
@@ -1,4 +1,5 @@
 import inspect
+from collections import namedtuple
 
 import numpy as np
 import pandas as pd
@@ -217,3 +218,20 @@ def test_flatten_with_none():
     flat, treedef = tree_flatten(None)
     assert flat == []
     assert treedef is None
+
+
+def test_leaf_names_with_none():
+    names = leaf_names(None)
+    assert names == []
+
+
+def test_flatten_with_namedtuple():
+    bla = namedtuple("bla", ["a", "b"])(1, 2)
+    flat, _ = tree_flatten(bla)
+    assert flat == [1, 2]
+
+
+def test_names_with_namedtuple():
+    bla = namedtuple("bla", ["a", "b"])(1, 2)
+    names = leaf_names(bla)
+    assert names == ["a", "b"]

--- a/tests/test_tree_util.py
+++ b/tests/test_tree_util.py
@@ -211,3 +211,9 @@ def test_tree_yield(example_tree, example_treedef, example_flat):
             aaae(a, b)
         else:
             assert a == b
+
+
+def test_flatten_with_none():
+    flat, treedef = tree_flatten(None)
+    assert flat == []
+    assert treedef is None

--- a/tests/test_tree_util.py
+++ b/tests/test_tree_util.py
@@ -50,8 +50,7 @@ def extended_treedef():
 @pytest.fixture
 def extended_registry():
     types = ["pandas.DataFrame", "pandas.Series", "numpy.ndarray"]
-    options = {"pandas.DataFrame": {"columns": "value"}}
-    return get_registry(types=types, options=options)
+    return get_registry(types=types)
 
 
 def test_tree_flatten(example_tree, example_flat, example_treedef):
@@ -182,16 +181,6 @@ def _assert_list_with_arrays_is_equal(list1, list2):
             assert first == second
 
 
-def test_flatten_df_with_value_column(extended_registry):
-    df = pd.DataFrame(index=["a", "b", "c"])
-    df["value"] = [1, 2, 3]
-    df["bla"] = [4, 5, 6]
-
-    flat, _ = tree_flatten(df, registry=extended_registry)
-
-    assert flat == [1, 2, 3]
-
-
 def test_flatten_df_all_columns():
     registry = get_registry(types=["pandas.DataFrame"])
     df = pd.DataFrame(index=["a", "b", "c"])
@@ -200,7 +189,7 @@ def test_flatten_df_all_columns():
 
     flat, _ = tree_flatten(df, registry=registry)
 
-    assert flat == [1, 2, 3, 4, 5, 6]
+    assert flat == [1, 4, 2, 5, 3, 6]
 
 
 def test_tree_yield(example_tree, example_treedef, example_flat):

--- a/tests/test_typecheck.py
+++ b/tests/test_typecheck.py
@@ -1,0 +1,22 @@
+from collections import namedtuple
+from typing import NamedTuple
+
+from pybaum.typecheck import get_type
+
+
+def test_namedtuple_is_discovered():
+    bla = namedtuple("bla", ["a", "b"])(1, 2)
+    assert get_type(bla) == namedtuple
+
+
+def test_typed_namedtuple_is_discovered():
+    class Blubb(NamedTuple):
+        a: int
+        b: int
+
+    blubb = Blubb(1, 2)
+    assert get_type(blubb) == namedtuple
+
+
+def test_standard_tuple_is_not_discovered():
+    assert get_type((1, 2)) == tuple


### PR DESCRIPTION
Currently we have only list, dict and tuple as default pytree containers. 

Jax also has:

- [x] None
- [x] collections.namedtuple and typing.NamedTuple
- [x] collections.OrderedDict 

